### PR TITLE
add YT demo link to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 = Gradle Initializer image:https://travis-ci.org/bmuschko/gradle-initializr.svg?branch=master["Build Status", link="https://travis-ci.org/bmuschko/gradle-initializr"]
 
-Gradle Initializer provides a web-based service for generating quickstart Gradle projects. The application provides two different interfaces: a web-based UI and an endpoint for generating projects via `curl`. Under the covers, Gradle Initializer uses the link:https://docs.gradle.org/current/userguide/embedding.html[Tooling API] to invoke the functionality of the link:https://docs.gradle.org/current/userguide/build_init_plugin.html[Build Init plugin]. A quickstart project is bundled and downloaded as ZIP or TAR file.
+Gradle Initializer provides a web-based service for generating quickstart Gradle projects. The application provides two different interfaces: a web-based UI (link:https://www.youtube.com/watch?v=E1huTB6yfRs[demo]) and an endpoint for generating projects via `curl`. Under the covers, Gradle Initializer uses the link:https://docs.gradle.org/current/userguide/embedding.html[Tooling API] to invoke the functionality of the link:https://docs.gradle.org/current/userguide/build_init_plugin.html[Build Init plugin]. A quickstart project is bundled and downloaded as ZIP or TAR file.
 
 == Using the web UI
 
-The web user interface is available by opening the URL link:https://gradle-initializr.cleverapps.io/[https://gradle-initializr.cleverapps.io/] in the browser of your choice. Simply select the options for your target project and press the "Generate" button to download the archive containing the project files.
+The web user interface (link:https://www.youtube.com/watch?v=E1huTB6yfRs[YT demo]) is available by opening the URL link:https://gradle-initializr.cleverapps.io/[https://gradle-initializr.cleverapps.io/] in the browser of your choice. Simply select the options for your target project and press the "Generate" button to download the archive containing the project files.
 
 == Using curl
 


### PR DESCRIPTION
Links a Youtube video to the README starting a project with gradle-initializr web page.

Links 2x: in first intro paragraph and "Using the web UI".